### PR TITLE
Ensure that $HomeTestFiles$ exists for Winbatch Tests

### DIFF
--- a/CLIENT_DATA/sub-scripts/winbatch.opsiscript
+++ b/CLIENT_DATA/sub-scripts/winbatch.opsiscript
@@ -12,6 +12,8 @@ if ($Flag_winst_winbatch$ = "on") or ($MasterFlag$ = "on")
 	; start testing
 	set $TestResult$ = "o.k."
 
+	Files_testFiles
+
 	; WinBatch Sections
 	
 
@@ -1447,6 +1449,8 @@ msiexec /i "$HomeTestFiles$\testFiles\dummy.msi" /l* "$HomeTestFiles$\dummy.inst
 [winbatch_start_helper_c]
 "$HomeTestFiles$\testFiles\$opsi_script_test_helper_bin$" --log="$HomeTestFiles$\testFiles\opsi-script-test-helper-win\admin.log"
 
+[Files_testFiles]
+checkTargetPath = "$HomeTestFiles$"
 
 [Files_copy_msi_exe_2_c]
 copy "%ScriptPath%\test-files\testFiles\*.msi" "$HomeTestFiles$\testFiles"


### PR DESCRIPTION
In `winbatch.opsiscript` the `Winbatch_msi_standard` routine assumes that it can write a log file to `$HomeTestFiles$\dummy.install_log.txt`. The problem is however, that this log file does not always exist when `winbatch.opsiscript` is started, because the `$HomeTestFiles$` directory might get deleted by another sub script beforehand. This is especially the case if `alltests` is `on`. Only if `alltests` is `off` and only the winbatch tests are turned on, the directory is setup correctly for `winbatch.opsiscript` in the current `experimental` version.

This pull request fixes this issue by creating `$HomeTestFiles$` using `checkTargetPath` every time `winbatch.opsiscript` is started.