### PR TITLE
Fix wrongly failing test sleepSeconds on Linux

### DIFF
--- a/CLIENT_DATA/opsi-script-test.opsiscript
+++ b/CLIENT_DATA/opsi-script-test.opsiscript
@@ -4989,15 +4989,13 @@ if ($Flag_winst_controls$ = "on") or ($MasterFlag$ = "on")
 	else ; windows
 		markTime
 		set $list1$ = getOutStreamFromSection("ShellInAnIcon_time")
-		set $tmp$ = takeString(0, $list1$)
-		Set $ConstTest$ =  takeString(3, splitStringOnWhitespace($tmp$))
+		set $ConstTest$ = takeString(0, $list1$)
 		comment "sleepSeconds 2"
 		marktime
 		sleepSeconds 2
 		difftime
 		set $list1$ = getOutStreamFromSection("ShellInAnIcon_time")
-		set $tmp$ = takeString(0, $list1$)
-		set $CompValue$ = takeString(3, splitStringOnWhitespace($tmp$))
+		set $CompValue$ = takeString(0, $list1$)
 		if $ConstTest$ < $CompValue$
 			comment "sleepSeconds assumed passed"
 		else
@@ -7869,7 +7867,7 @@ goto end
 rem time /t
 
 [ShellInAnIcon_time]
-date
+date "+%s"
 
 [DosInAnIcon_retrieve_systemtype]
 @echo off


### PR DESCRIPTION
Instead of using the default format of `date`, display the current unix timestamp. This way we avoid format inconsistencies across platforms and simplify the test because we don't need to parse the output of `date` anymore.

This resolves an issue I encountered where the `sleepSeconds` test would fail even though `sleepSeconds` works correctly. For GNU coreutils the default output of `date` looks like this: `Mi, 19. Feb 2020 10:00:59`. The previous code would then set `$ConstTest$` and `$CompValue$` to the current year - meaning that the test would only succeed if started shortly before new years eve.

I tested both the issue and the fix with the latest `opsi-script` build from the `experimental` branch of [opsi-org/lazarus](https://github.com/opsi-org/lazarus).